### PR TITLE
add CI for DockerHub, for prod and DEV channels

### DIFF
--- a/.github/workflows/DEV_build_push_docker.yml
+++ b/.github/workflows/DEV_build_push_docker.yml
@@ -1,0 +1,34 @@
+name: DEV - Build and Push docker image to DockerHub
+
+on:
+  workflow_dispatch:
+    branches:
+      - 'dev'
+
+jobs:
+  docker:
+    name: docker build and push
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: bepolytech/ulbdiscordbot:dev

--- a/.github/workflows/DEV_build_push_docker.yml
+++ b/.github/workflows/DEV_build_push_docker.yml
@@ -2,8 +2,6 @@ name: DEV - Build and Push docker image to DockerHub
 
 on:
   workflow_dispatch:
-    branches:
-      - dev
 
 jobs:
   docker:

--- a/.github/workflows/DEV_build_push_docker.yml
+++ b/.github/workflows/DEV_build_push_docker.yml
@@ -3,7 +3,7 @@ name: DEV - Build and Push docker image to DockerHub
 on:
   workflow_dispatch:
     branches:
-      - 'dev'
+      - dev
 
 jobs:
   docker:
@@ -13,6 +13,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: 'dev'
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build_push_docker.yml
+++ b/.github/workflows/build_push_docker.yml
@@ -1,7 +1,11 @@
 name: Build and Push docker image to DockerHub
 
 on:
-  [workflow_dispatch, pull_request, push]:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'main'
+  push:
     branches:
       - 'main'
 
@@ -13,6 +17,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: 'main'
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build_push_docker.yml
+++ b/.github/workflows/build_push_docker.yml
@@ -1,0 +1,34 @@
+name: Build and Push docker image to DockerHub
+
+on:
+  [workflow_dispatch, pull_request, push]:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    name: docker build and push
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: bepolytech/ulbdiscordbot:latest


### PR DESCRIPTION
github actions to build and push to DockerHub the respective prod and dev docker images. dev action is only run manually, prod action is run on push, pull-request or manually.