### PR TITLE
Feedback cmd, unregistration possibility and yearly update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM python:3
+#FROM python:3
+FROM python:3.8.6-alpine
 # use python:3.11.0rc2-slim for less vulnerabilities ? (from `docker scan`)
+# use python:3.8.6 for no pip dependencies build errors ?
+# use python:alpine for reduced size
+# => python:3.8.6-alpine
 
 WORKDIR /usr/src/ulbdiscordbot
 
+RUN python3 -m pip install --upgrade pip
+
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+#RUN pip3 install --extra-index-url https://alpine-wheels.github.io/index --no-cache-dir -r requirements.txt # if wheels dependencies build errors when using alpine
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -3,3 +3,4 @@ from .database import *
 from .email import *
 from .registration import *
 from .utils import *
+from .yearlyUpdate import *

--- a/classes/feedback.py
+++ b/classes/feedback.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import logging
+from typing import List
+
+import disnake
+
+from bot import Bot
+
+
+class FeedbackType:
+    issu = "problème"
+    improve = "amélioration"
+
+
+class FeedbackModal(disnake.ui.Modal):
+    def __init__(self, bot: Bot, type: FeedbackType) -> None:
+        self.bot: Bot = bot
+        self.type: FeedbackType = type
+        components: List[disnake.ui.TextInput] = None
+        if type == FeedbackType.issu:
+            components = [
+                disnake.ui.TextInput(
+                    label="Problème",
+                    placeholder="Quel est le problème que vous avez rencontré",
+                    style=disnake.TextInputStyle.paragraph,
+                    custom_id="feedback",
+                )
+            ]
+        elif type == FeedbackType.improve:
+            components = [
+                disnake.ui.TextInput(
+                    label="Amélioration",
+                    placeholder="Qu'est-ce que vous voudriez améliorer ?",
+                    style=disnake.TextInputStyle.paragraph,
+                    custom_id="feedback",
+                )
+            ]
+        else:
+            raise TypeError("arg 'type' should be a 'FeedbackType'.")
+        super().__init__(title="Ulb registration - Feedback", components=components)
+
+    async def callback(self, interaction: disnake.ModalInteraction, /) -> None:
+        await interaction.response.defer(with_message=True, ephemeral=True)
+        logging.trace(f"[Feedback] Returning {self.type} feedback by {interaction.author} from {interaction.guild}")
+        feedback: str = interaction.text_values.get("feedback")
+        if self.type == FeedbackType.issu:
+            embed = disnake.Embed(
+                title="Feedback - Problème",
+                description="> " + "\n> ".join(feedback.splitlines()),
+                color=disnake.Color.red(),
+            )
+        elif self.type == FeedbackType.improve:
+            embed = disnake.Embed(
+                title="Feedback - Amélioration",
+                description="> " + "\n> ".join(feedback.splitlines()),
+                color=disnake.Color.teal(),
+            )
+        embed.add_field(
+            name="**__Origine__**",
+            value=f"**User :** {interaction.author}\n**Server :** {interaction.guild}\n**Date :** {interaction.created_at.isoformat()}",
+        )
+        await self.bot.log_channel.send(embed=embed)
+        await interaction.edit_original_response(
+            embed=disnake.Embed(
+                title="Feedback",
+                description="Merci beaucoup pour votre feedback !\nCelui-ci a bien été envoyé et sera pris en compte.",
+                color=disnake.Color.blue(),
+            )
+        )
+        logging.trace(f"[Feedback] feedback {self.type} by {interaction.author} from {interaction.guild} ended")

--- a/classes/registration.py
+++ b/classes/registration.py
@@ -17,6 +17,7 @@ from .database import Database
 from .database import DatabaseNotLoadedError
 from .database import UlbGuild
 from .email import EmailManager
+from .utils import remove_user
 from .utils import update_user
 from bot import Bot
 
@@ -610,23 +611,7 @@ class Unregister(disnake.ui.View):
             await inter.response.edit_message(embed=self.embeds[1], view=self)
         else:
             await inter.response.edit_message(embed=self.embeds[2], view=None)
-            user_data = Database.ulb_users.get(inter.author)
-            Database.delete_user(inter.user)
-            for guild, guild_data in self.guilds:
-                member = guild.get_member(inter.user.id)
-                try:
-                    await member.remove_roles(guild_data.role)
-                except disnake.HTTPException:
-                    logging.error(
-                        f"[Cog:Admin] [Delete user {inter.user.name}:{inter.user.id}] Not able to remove role {guild_data.role.name}:{guild_data.role.id} of guild {guild.name}:{guild.id}."
-                    )
-                if guild_data.rename and member.nick == user_data.name:
-                    try:
-                        await member.edit(nick=None)
-                    except disnake.HTTPException:
-                        logging.warning(
-                            f"[Cog:Admin] [Delete user {inter.user.name}:{inter.user.id}] Not able to remove nickname"
-                        )
+            await remove_user(inter.author)
             await inter.edit_original_response(embed=self.embeds[3])
 
     async def on_timeout(self) -> None:

--- a/classes/registration.py
+++ b/classes/registration.py
@@ -145,7 +145,7 @@ class Registration:
             await inter.edit_original_response(
                 embed=disnake.Embed(
                     title=cls._title,
-                    description=f"Vous avez récement dépassé le nombre de tentative de vérification de votre adresse email.\nVous pourrez à nouveau essayer dans {(cls.user_timeout_time - (cls._users_timeout.get(target).second - datetime.now().second))//60} min",
+                    description=f"Vous avez récement dépassé le nombre de tentatives de vérification de votre adresse email.\nVous pourrez à nouveau essayer dans {(cls.user_timeout_time - (cls._users_timeout.get(target).second - datetime.now().second))//60} minutes.",
                     color=disnake.Colour.orange(),
                 ).set_thumbnail(Bot.ULB_image)
             )
@@ -183,7 +183,7 @@ class Registration:
             await inter.edit_original_message(
                 embed=disnake.Embed(
                     title=self._title,
-                    description=f"⛔ Tu es déjà associé à l'adresse email suivante : **{ulb_user.email}**.",
+                    description=f"⛔ Ton compte est déjà associé à l'adresse email suivante : **{ulb_user.email}**.",
                     color=disnake.Colour.dark_orange(),
                 ).set_thumbnail(Bot.ULB_image)
             )
@@ -210,7 +210,7 @@ class Registration:
         # Create UI elements for registration
         self.registration_embed = disnake.Embed(
             title=self._title,
-            description="> Ce serveur est réservé aux étudiants de l'ULB.\n> Pour accéder à ce serveur, tu dois vérifier ton identité avec ton addresse email **ULB**.",
+            description="> Ce serveur est réservé aux étudiant.e.s de l'ULB.\n> Pour accéder à ce serveur, tu dois vérifier ton identité avec ton addresse email **ULB**.",
             color=self._color,
         ).set_thumbnail(Bot.ULB_image)
         self.registration_view = disnake.ui.View()
@@ -225,9 +225,9 @@ class Registration:
             timeout=60 * 5,
             components=[
                 disnake.ui.TextInput(
-                    label="Addresse mail ULB (@ulb.be) :",
+                    label="Addresse email ULB (@ulb.be) :",
                     custom_id="email",
-                    placeholder="ex : théodore.verhaegen@ulb.be",
+                    placeholder="ex : theodore.verhaegen@ulb.be",
                 ),
             ],
             callback=self._callback_info_modal,
@@ -299,7 +299,7 @@ class Registration:
             self.registration_embed.clear_fields()
             self.registration_embed.add_field(
                 f"⚠️ Domaine incorrect",
-                value=f"**{self.email}** n'est pas une adresse email **ULB**.\nUtilise ton adresse email **@ulb.be**.",
+                value=f"**{self.email}** n'est pas une adresse email officielle **ULB**.\nUtilise ton adresse email **@ulb.be**.",
             )
             self.msg = await inter.edit_original_message(embed=self.registration_embed, view=self.registration_view)
             return
@@ -312,7 +312,7 @@ class Registration:
                 self.registration_embed.colour = disnake.Colour.red()
                 self.registration_embed.remove_footer().add_field(
                     f"⛔ Adresse email non disponible",
-                    value=f"**{self.email}** est déjà associée à un autre utilisateur discord.\nSi cette adresse email est bien la tienne et que quelqu'un a eu accès à ta boite mail pour se faire passer pour toi, envoie un message à {self._contact_user.mention if self._contact_user else 'un administrateur du serveur.'}.",
+                    value=f"**{self.email}** est déjà associée à un.e autre utilisateur.rice discord.\nSi cette adresse email est bien la tienne et que quelqu'un a eu accès à ta boite mail pour se faire passer pour toi, envoie un message à {self._contact_user.mention if self._contact_user else 'un.e administrateur.rice du serveur.'}.",
                 )
                 await inter.edit_original_message(embed=self.registration_embed, view=None)
                 await self._stop()
@@ -341,7 +341,7 @@ class Registration:
         self.token_verification_embed = (
             disnake.Embed(
                 title=self._title,
-                description=f"""Un token à été envoyé à l'addresse email ***{self.email}***.""",
+                description=f"""Un token a été envoyé à l'addresse email ***{self.email}***.""",
                 color=self._color,
             )
             .set_thumbnail(url=Bot.ULB_image)
@@ -389,7 +389,7 @@ class Registration:
             await inter.edit_original_response(
                 embed=self.token_verification_embed.add_field(
                     name="❌",
-                    value=f"Une erreur s'est produite durant l'envoie de l'email. Si cela se produit à nouveau, veuillez contacter {self._contact_user.mention if self._contact_user else 'un administrateur'}",
+                    value=f"Une erreur s'est produite durant l'envoi de l'email. Si cela se produit à nouveau, veuillez contacter {self._contact_user.mention if self._contact_user else 'un.e administrateur.rice'}",
                 ),
                 view=None,
             )
@@ -465,7 +465,7 @@ class Registration:
                 self.token_verification_embed.colour = disnake.Colour.red()
                 self.token_verification_embed.remove_footer().add_field(
                     name="⛔ Token invalide",
-                    value=f"""Nombre de tentative dépassée.\nTu dois attendre {self.user_timeout_time//60} minutes avant de pouvoir recommencer.""",
+                    value=f"""Nombre de tentatives dépassé.\nTu dois attendre {self.user_timeout_time//60} minutes avant de pouvoir recommencer.""",
                 )
                 await inter.edit_original_message(
                     embed=self.token_verification_embed,
@@ -578,12 +578,12 @@ class Unregister(disnake.ui.View):
         self.embeds = [
             disnake.Embed(
                 title="Déjà vérifié",
-                description=f"Tu es actuellement associé à l'adresse email `{Database.ulb_users.get(self.inter.author).email}`\nTu peux supprimer ton adresse email en cliquant ci-dessous.",
+                description=f"Ton compte est actuellement associé à l'adresse email `{Database.ulb_users.get(self.inter.author).email}`\nTu peux supprimer ton adresse email en cliquant ci-dessous.",
                 colour=disnake.Colour.teal(),
             ),
             disnake.Embed(
                 title="Suppression des données",
-                description=f"⚠️ En supprimant ton adresse email, tu n'auras plus accès aux serveurs restreint aux utilisateurs vérifiés dont tu fais parti:\n`"
+                description=f"⚠️ En supprimant ton adresse email, tu n'auras plus accès aux serveurs restreints aux utilisateurs vérifiés dont tu fais parti:\n`"
                 + "`\n`".join([g.name for g, _ in self.guilds])
                 + "`",
                 colour=disnake.Colour.orange(),
@@ -593,7 +593,7 @@ class Unregister(disnake.ui.View):
             ),
             disnake.Embed(
                 title="Suppression des données",
-                description="Ton adresse email à bien été supprimées !",
+                description="Ton adresse email à bien été supprimée !",
                 colour=disnake.Colour.teal(),
             ),
         ]
@@ -607,7 +607,7 @@ class Unregister(disnake.ui.View):
     async def delete_data(self, button: disnake.Button, inter: disnake.MessageInteraction):
         if not self.confirmation:
             self.confirmation = True
-            button.label = "Confirmez"
+            button.label = "Confirmer"
             await inter.response.edit_message(embed=self.embeds[1], view=self)
         else:
             await inter.response.edit_message(embed=self.embeds[2], view=None)
@@ -644,7 +644,7 @@ class AdminAddUserModal(disnake.ui.Modal):
         Database.set_user(self.user, name, email)
         await interaction.edit_original_response(
             embed=disnake.Embed(
-                description=f"{self.user.mention} a bien été ajouté à la base de donnée", color=disnake.Color.green()
+                description=f"{self.user.mention} a bien été ajouté.e à la base de donnée", color=disnake.Color.green()
             )
         )
 
@@ -668,7 +668,7 @@ class AdminEditUserModal(disnake.ui.Modal):
             ),
         ]
 
-        super().__init__(title=f"Mis à jour d'un utilisateur", components=components, timeout=10 * 60)
+        super().__init__(title=f"Mis à jour d'un.e utilisateur.rice", components=components, timeout=10 * 60)
 
     async def callback(self, interaction: disnake.ModalInteraction, /) -> None:
         await interaction.response.defer(ephemeral=True)

--- a/classes/yearlyUpdate.py
+++ b/classes/yearlyUpdate.py
@@ -18,7 +18,7 @@ class YearlyUpdate(disnake.ui.View):
         await inter.response.send_message(
             embed=disnake.Embed(
                 title="Yearly-update",
-                description="Cette commande va supprimer **TOUS** les utilisateurs vérifiés et leur envoyer un message leur demander de vérifier leur adresse email à nouveau.\nCette commande ne devrait etre utilisé uniquement en début de chaque année académique.\nEtes-vous sur de vouloir utiliser cette commande ?",
+                description="Cette commande va supprimer **TOUS** les utilisateur.rice.s vérifié.e.s et leur envoyer un message leur demandant de vérifier leur adresse email ULB à nouveau.\nCette commande ne devrait etre utilisée uniquement en début de chaque année académique (vers fin Octobre, début Novembre, le temps que les inscriptions se finalisent).\n**Êtes-vous sûr.e de vouloir utiliser cette commande ?**",
                 color=disnake.Color.orange(),
             ),
             view=new_view,
@@ -29,7 +29,7 @@ class YearlyUpdate(disnake.ui.View):
         await user.send(
             embed=disnake.Embed(
                 title="ULB accès retiré",
-                description=f"Ton accès aux serveurs ULB a été retiré pour la raison suivante : *{self.reason}*.\nUtilise **/ulb** pour re-vérifier ton adresse email ULB afin d'avoir à nouveau accès aux serveurs ULB.",
+                description=f"Ta vérification aux serveurs Discord ULB a été retirée pour la raison suivante : *{self.reason}*.\nUtilise **/ulb** pour re-vérifier ton adresse email ULB afin d'avoir à nouveau accès aux serveurs ULB sur Discord.",
             )
         )
 

--- a/classes/yearlyUpdate.py
+++ b/classes/yearlyUpdate.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import logging
+
+import disnake
+
+from .utils import remove_user
+from classes.database import Database
+
+
+class YearlyUpdate(disnake.ui.View):
+    def __init__(self, reason: str):
+        super().__init__()
+        self.reason = reason
+
+    @classmethod
+    async def new(cls, reason: str, inter: disnake.ApplicationCommandInteraction):
+        new_view = cls(reason)
+        await inter.response.send_message(
+            embed=disnake.Embed(
+                title="Yearly-update",
+                description="Cette commande va supprimer **TOUS** les utilisateurs vérifiés et leur envoyer un message leur demander de vérifier leur adresse email à nouveau.\nCette commande ne devrait etre utilisé uniquement en début de chaque année académique.\nEtes-vous sur de vouloir utiliser cette commande ?",
+                color=disnake.Color.orange(),
+            ),
+            view=new_view,
+        )
+
+    async def remove_and_notify(self, user: disnake.User):
+        await remove_user(user)
+        await user.send(
+            embed=disnake.Embed(
+                title="ULB accès retiré",
+                description=f"Ton accès aux serveurs ULB a été retiré pour la raison suivante : *{self.reason}*.\nUtilise **/ulb** pour re-vérifier ton adresse email ULB afin d'avoir à nouveau accès aux serveurs ULB.",
+            )
+        )
+
+    @disnake.ui.button(label="Confirmer", style=disnake.ButtonStyle.danger)
+    async def confirm(self, button: disnake.Button, inter: disnake.ApplicationCommandInteraction):
+        await inter.response.edit_message(
+            embed=disnake.Embed(
+                title="Yearly-update", description="Removing and notifiyng all users...", color=disnake.Colour.orange()
+            ),
+            view=None,
+        )
+        logging.info("[yearly-update] Starting to remove and notify all users")
+        users = list(Database.ulb_users.keys())
+        for user in users:
+            await self.remove_and_notify(user)
+        logging.info("[yearly-update] All users removed and notified !")
+        if inter.is_expired():
+            await inter.channel.send(
+                embed=disnake.Embed(title="Yearly-update", description="Done !", color=disnake.Colour.teal())
+            )
+        else:
+            inter.edit_original_response(
+                embed=disnake.Embed(title="Yearly-update", description="Done !", color=disnake.Colour.teal())
+            )

--- a/cogs/Admin.py
+++ b/cogs/Admin.py
@@ -36,7 +36,7 @@ class Admin(commands.Cog):
 
     @commands.slash_command(
         name="yearly-update",
-        description="Retirer tous les utilisateurs en envoyant une notification",
+        description="Retirer tous les utilisateur.rice.s en leur envoyant une notification par email",
         guilds=[int(os.getenv("ADMIN_GUILD_ID"))],
         default_member_permissions=disnake.Permissions.all(),
         dm_permission=False,
@@ -60,42 +60,42 @@ class Admin(commands.Cog):
     async def user(self, inter):
         pass
 
-    @user.sub_command(name="add", description="Ajouter un utilisateur discord.")
+    @user.sub_command(name="add", description="Ajouter un.e utilisateur.rice discord.")
     async def user_set(
         self,
         inter: disnake.ApplicationCommandInteraction,
         user_id: str = commands.Param(
-            description="L'id discord de l'utilisateur à ajouter.", min_length=18, max_length=18
+            description="L'ID discord de l'utilisateur.rice à ajouter.", min_length=18, max_length=18
         ),
     ):
         user = self.bot.get_user(int(user_id))
         if not user:
             await inter.response.send_message(
                 embed=disnake.Embed(
-                    description=f"Pas d'utilisateur discord avec user id = {user_id}.", color=disnake.Colour.red()
+                    description=f"Pas d'utilisateur.rice discord avec User ID = {user_id}.", color=disnake.Colour.red()
                 ),
                 ephemeral=True,
             )
 
         await inter.response.send_modal(AdminAddUserModal(user))
 
-    @user.sub_command(name="edit", description="Editer un utilisateur ULB (un seul paramètre requis)")
+    @user.sub_command(name="edit", description="Editer un.e utilisateur.rice ULB (un seul paramètre requis)")
     async def user_edit(
         self,
         inter: disnake.ApplicationCommandInteraction,
         user_id: str = commands.Param(
-            description="L'id discord de l'utilisateur ULB à éditer.", min_length=18, max_length=18, default=None
+            description="L'ID discord de l'utilisateur.rice ULB à éditer.", min_length=18, max_length=18, default=None
         ),
-        name: str = commands.Param(description="Le nom de l'utilisateur ULB à éditer.", default=None),
-        email: str = commands.Param(description="L'email de l'utilisateur ULB à éditer.", default=None),
+        name: str = commands.Param(description="Le nom de l'utilisateur.rice ULB à éditer.", default=None),
+        email: str = commands.Param(description="L'email de l'utilisateur.rice ULB à éditer.", default=None),
     ):
         if user_id:
             user = self.bot.get_user(int(user_id))
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'id ne correspond à aucun utilisateur discord connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'ID ne correspond à aucun.e utilisateur.rice Discord connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -104,8 +104,8 @@ class Admin(commands.Cog):
             if user not in Database.ulb_users.keys():
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'id ne correspond à aucun utilisateur ULB.",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'ID ne correspond à aucun.e utilisateur.rice ULB.",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -116,8 +116,8 @@ class Admin(commands.Cog):
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"Le nom ne correspond à aucun utilisateur connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"Le nom ne correspond à aucun.e utilisateur.rice connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -128,8 +128,8 @@ class Admin(commands.Cog):
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'email ne correspond à aucun utilisateur connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'email ne correspond à aucun.e utilisateur.rice connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -138,8 +138,8 @@ class Admin(commands.Cog):
         else:
             await inter.response.send_message(
                 embed=disnake.Embed(
-                    title="Info de l'utilisateur",
-                    description=f"Spécifiez l'id, le nom ou l'email dans la commande.",
+                    title="Info de l'utilisateur.rice",
+                    description=f"Spécifiez l'ID, le nom ou l'email dans la commande.",
                     color=disnake.Colour.orange(),
                 ),
                 ephemeral=True,
@@ -148,22 +148,22 @@ class Admin(commands.Cog):
         await inter.response.send_modal(AdminEditUserModal(user))
 
     @user.sub_command(
-        name="info", description="Voir les informations d'un utilisateur enregistré (un seul paramètre requis)"
+        name="info", description="Voir les informations d'un.e utilisateur.rice enregistré.e (un seul paramètre requis)"
     )
     async def user_info(
         self,
         inter: disnake.ApplicationCommandInteraction,
         user_id: str = commands.Param(
-            description="L'id discord de l'utilisateur ULB dont vous voulez voir les informations.",
+            description="L'ID Discord de l'utilisateur.rice ULB dont vous voulez voir les informations.",
             min_length=18,
             max_length=18,
             default=None,
         ),
         name: str = commands.Param(
-            description="Le nom de l'utilisateur ULB dont vous voulez voir les informations.", default=None
+            description="Le nom de l'utilisateur.rice ULB dont vous voulez voir les informations.", default=None
         ),
         email: str = commands.Param(
-            description="L'email de l'utilisateur ULB dont vous voulez voir les informations.", default=None
+            description="L'email de l'utilisateur.rice ULB dont vous voulez voir les informations.", default=None
         ),
     ):
         if user_id:
@@ -171,8 +171,8 @@ class Admin(commands.Cog):
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'id ne correspond à aucun utilisateur discord connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'ID ne correspond à aucun.e utilisateur.rice Discord connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -181,8 +181,8 @@ class Admin(commands.Cog):
             if user not in Database.ulb_users.keys():
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'id ne correspond à aucun utilisateur ULB.",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'ID ne correspond à aucun.e utilisateur.rice ULB.",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -193,8 +193,8 @@ class Admin(commands.Cog):
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"Le nom ne correspond à aucun utilisateur connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"Le nom ne correspond à aucun.e utilisateur.rice connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -205,8 +205,8 @@ class Admin(commands.Cog):
             if user == None:
                 await inter.response.send_message(
                     embed=disnake.Embed(
-                        title="Info de l'utilisateur",
-                        description=f"L'email ne correspond à aucun utilisateur connu",
+                        title="Info de l'utilisateur.rice",
+                        description=f"L'email ne correspond à aucun.e utilisateur.rice connu.e",
                         color=disnake.Colour.orange(),
                     ),
                     ephemeral=True,
@@ -215,8 +215,8 @@ class Admin(commands.Cog):
         else:
             await inter.response.send_message(
                 embed=disnake.Embed(
-                    title="Info de l'utilisateur",
-                    description=f"Spécifiez l'id, le nom ou l'email dans la commande.",
+                    title="Info de l'utilisateur.rice",
+                    description=f"Spécifiez l'ID, le nom ou l'email dans la commande.",
                     color=disnake.Colour.orange(),
                 ),
                 ephemeral=True,
@@ -226,23 +226,23 @@ class Admin(commands.Cog):
         guilds_name: List[str] = [f"`{guild.name}`" for guild in Database.ulb_guilds.keys() if user in guild.members]
         await inter.response.send_message(
             embed=disnake.Embed(
-                title="Info de l'utilisateur",
-                description=f"**User id :** `{user.id}`\n**Nom :** {user_data.name}\n**Adresse email :** {f'*{user_data.email}*' if user_data.email else '*N/A*'}\n**ULB serveurs :** {','.join(guilds_name) if guilds_name else '*Aucun...*'}",
+                title="Info de l'utilisateur.rice",
+                description=f"**User ID :** `{user.id}`\n**Nom :** {user_data.name}\n**Adresse email :** {f'*{user_data.email}*' if user_data.email else '*N/A*'}\n**ULB serveurs :** {','.join(guilds_name) if guilds_name else '*Aucun...*'}",
                 color=disnake.Colour.green(),
             ),
             ephemeral=True,
         )
 
-    @user.sub_command(name="delete", description="Supprimer un utilisateur enregistré.")
+    @user.sub_command(name="delete", description="Supprimer un.e utilisateur.rice enregistré.e.")
     async def user_delete(
         self,
         inter: disnake.ApplicationCommandInteraction,
         user_id: str = commands.Param(
-            description="L'id discord de l'utilisateur ULB à supprimer.", min_length=18, max_length=18
+            description="L'ID Discord de l'utilisateur.rice ULB à supprimer.", min_length=18, max_length=18
         ),
-        name: str = commands.Param(description="Le nom ULB de l'utilisateur ULB à supprimer (pour confirmation)"),
+        name: str = commands.Param(description="Le nom ULB de l'utilisateur.rice ULB à supprimer (pour confirmation)"),
         remove_ulb: str = commands.Param(
-            description="Retirer l'utilisateur du role ULB dans tous les serveurs.", choices=["Oui", "Non"]
+            description="Retirer l'utilisateur.rice du role ULB dans tous les serveurs.", choices=["Oui", "Non"]
         ),
     ):
         await inter.response.defer(ephemeral=True)
@@ -250,7 +250,7 @@ class Admin(commands.Cog):
         if not user:
             await inter.edit_original_response(
                 embed=disnake.Embed(
-                    description=f"Pas d'utilisteur discord avec user id = {user_id}", color=disnake.Colour.red()
+                    description=f"Pas d'utilisteur.rice Discord avec User ID = {user_id}", color=disnake.Colour.red()
                 )
             )
             return
@@ -259,14 +259,14 @@ class Admin(commands.Cog):
         if not user_data:
             await inter.edit_original_response(
                 embed=disnake.Embed(
-                    description=f"Pas d'utilisteur ULB avec user id = {user_id}", color=disnake.Colour.red()
+                    description=f"Pas d'utilisteur.rice ULB avec User ID = {user_id}", color=disnake.Colour.red()
                 )
             )
             return
 
         if user_data.name.lower() != name.lower():
             await inter.edit_original_response(
-                embed=disnake.Embed(description="L'id et le nom ne correspondent pas...", color=disnake.Color.red())
+                embed=disnake.Embed(description="L'ID et le nom ne correspondent pas...", color=disnake.Color.red())
             )
         else:
             Database.delete_user(user)
@@ -294,14 +294,14 @@ class Admin(commands.Cog):
                                     )
 
             embed = disnake.Embed(
-                title=f"L'utilisateur à bien été supprimé !",
-                description=f"**User id :** `{user_id}`\n**Nom :** {user_data.name}\n**Adresse email :** *{user_data.email}*",
+                title=f"L'utilisateur.rice à bien été supprimé.e !",
+                description=f"**User ID :** `{user_id}`\n**Nom :** {user_data.name}\n**Adresse email :** *{user_data.email}*",
                 color=disnake.Color.green(),
             )
             if error_roles:
                 embed.add_field(
                     name="⚠️",
-                    value="Les roles @ULB des serveurs suivants n'ont pas pu être retirés :\n"
+                    value="Les rôles @ULB des serveurs suivants n'ont pas pu être retirés :\n"
                     + "\n >".join(error_roles),
                 )
             await inter.edit_original_response(

--- a/cogs/Admin.py
+++ b/cogs/Admin.py
@@ -9,6 +9,7 @@ from disnake.ext import commands
 from bot import Bot
 from classes import Database
 from classes import utils
+from classes import YearlyUpdate
 from classes.registration import AdminAddUserModal
 from classes.registration import AdminEditUserModal
 
@@ -32,6 +33,23 @@ class Admin(commands.Cog):
         await inter.edit_original_response(
             embed=disnake.Embed(description="All servers updated !", color=disnake.Color.green())
         )
+
+    @commands.slash_command(
+        name="yearly-update",
+        description="Retirer tous les utilisateurs en envoyant une notification",
+        guilds=[int(os.getenv("ADMIN_GUILD_ID"))],
+        default_member_permissions=disnake.Permissions.all(),
+        dm_permission=False,
+    )
+    async def yearly_update(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        raison: str = commands.Param(
+            description="""La raison de l'update ("Vérification annuelle" par default")""",
+            default="Vérification annuelle",
+        ),
+    ):
+        await YearlyUpdate.new(raison, inter)
 
     @commands.slash_command(
         name="user",

--- a/cogs/Ulb.py
+++ b/cogs/Ulb.py
@@ -64,7 +64,7 @@ class Ulb(commands.Cog):
     async def setup(
         self,
         inter: ApplicationCommandInteraction,
-        role_ulb: disnake.Role = commands.Param(description='Le role "ULB" à donner aux membres vérifiés.'),
+        role_ulb: disnake.Role = commands.Param(description='Le rôle "**ULB**" à donner aux membres vérifiés.'),
         rename: str = commands.Param(
             description="Est-ce que les membres doivent être renommer avec leur vrai nom.",
             default="Oui",
@@ -79,8 +79,8 @@ class Ulb(commands.Cog):
         if inter.guild.me.top_role.permissions.manage_roles != True:
             await inter.edit_original_response(
                 embed=disnake.Embed(
-                    title="Setup du role ULB du servers",
-                    description=f"J'ai besoin d'avoir la permissions d'editer les roles pour pouvoir ajouter les membres vérifiés à {role_ulb.mention}.\nChangez mes permissions et réessayez.",
+                    title="Setup du rôle ULB du serveur",
+                    description=f"J'ai besoin d'avoir la permissions d'éditer les rôles pour pouvoir ajouter les membres vérifiés à {role_ulb.mention}.\nChangez mes permissions et réessayez.",
                     color=disnake.Colour.red(),
                 )
             )
@@ -89,8 +89,8 @@ class Ulb(commands.Cog):
         if rename == True and inter.guild.me.top_role.permissions.manage_nicknames != True:
             await inter.edit_original_response(
                 embed=disnake.Embed(
-                    title="Setup du role ULB du servers",
-                    description=f"J'ai besoin d'avoir la permissions d'editer les pseudos des membres pour pouvoir les renommer avec leur vrai nom.\nChangez mes permissions et réessayez.",
+                    title="Setup du rôle ULB du serveur",
+                    description=f"J'ai besoin d'avoir la permissions d'éditer les pseudos des membres pour pouvoir les renommer avec leur vrai nom.\nChangez mes permissions et réessayez.",
                     color=disnake.Colour.red(),
                 )
             )
@@ -99,8 +99,8 @@ class Ulb(commands.Cog):
         if role_ulb == inter.guild.default_role:
             await inter.edit_original_response(
                 embed=disnake.Embed(
-                    title="Setup du role ULB du servers",
-                    description=f"Le role {role_ulb.mention} ne peux pas être utilisé comme role **ULB** car c'est le role par défaut.",
+                    title="Setup du rôle ULB du serveur",
+                    description=f"Le rôle {role_ulb.mention} ne peux pas être utilisé comme role '**ULB**' car c'est le rôle par défaut.",
                     color=disnake.Color.red(),
                 )
             )
@@ -110,7 +110,7 @@ class Ulb(commands.Cog):
 
         Database.set_guild(inter.guild, role_ulb, rename)
         embed = disnake.Embed(
-            title="Setup du role ULB du servers",
+            title="Setup du rôle ULB du serveur",
             description=f"""✅ Setup confirmé !\n\n> Les nouveaux membres seront automatiquement ajoutés à {role_ulb.mention}"""
             + (" et renommés avec leur vrai nom " if rename else " ")
             + "une fois qu'ils auront vérifiés leur adresse email **ULB**.",
@@ -128,7 +128,7 @@ class Ulb(commands.Cog):
         if rename and inter.me.top_role <= role_ulb:
             embed.add_field(
                 name="⚠️",
-                value=f"Le role {inter.me.top_role.mention} doit être au dessus de {role_ulb.mention} pour pouvoir update le nom des utilisateurs enregistrés.",
+                value=f"Le rôle {inter.me.top_role.mention} doit être au dessus de {role_ulb.mention} pour pouvoir update le nom des utilisateur.rice.s enregistré.e.s.",
                 inline=False,
             )
         if embed.fields != []:
@@ -141,7 +141,7 @@ class Ulb(commands.Cog):
 
     @commands.slash_command(
         name="info",
-        description="Voir les settings pour ce serveurs",
+        description="Voir les settings pour ce serveur",
         default_member_permissions=disnake.Permissions.all(),
         dm_permission=False,
     )
@@ -170,7 +170,7 @@ class Ulb(commands.Cog):
 
         if inter.guild.me.top_role.permissions.manage_roles != True:
             embed.add_field(
-                name="❌", value="je n'ai pas la permissions de changer les roles des membres.", inline=False
+                name="❌", value="je n'ai pas la permissions de changer les rôles des membres.", inline=False
             )
 
         if guilddata.rename and inter.guild.me.top_role.permissions.manage_nicknames != True:
@@ -189,14 +189,14 @@ class Ulb(commands.Cog):
         if guilddata.rename and inter.me.top_role <= guilddata.role:
             embed.add_field(
                 name="⚠️",
-                value=f"Le role {inter.me.top_role.mention} doit être au dessus de {guilddata.role.mention} pour pouvoir update le nom des utilisateurs enregistrés.",
+                value=f"Le rôle {inter.me.top_role.mention} doit être au dessus de {guilddata.role.mention} pour pouvoir update le nom des utilisateurs enregistrés.",
                 inline=False,
             )
 
         if embed.fields == []:
             embed.add_field(
                 name="✅",
-                value="Pas de conflit de permission",
+                value="Aucun conflit de permission",
             )
         else:
             embed.color = disnake.Colour.orange()
@@ -231,8 +231,8 @@ class Ulb(commands.Cog):
             )
             await member.send(
                 embed=disnake.Embed(
-                    title=f"Bienvenu sur le server __**{member.guild.name}**__",
-                    description="""Ce serveur est reservé aux membre de l'ULB.\nPour acceder à ce serveur, tu dois vérifier ton identité avec ton addresse email **ULB** en utilisant la commande **"/ulb"**.""",
+                    title=f"Bienvenue sur le serveur __**{member.guild.name}**__",
+                    description="""Ce serveur est limité aux membre de l'**ULB**.\nPour accéder à ce serveur, tu dois vérifier ton identité avec ton addresse email **ULB** en utilisant la commande **"/ulb"**.""",
                     color=disnake.Color.teal(),
                 ).set_thumbnail(url=self.bot.ULB_image)
             )
@@ -265,8 +265,8 @@ class Ulb(commands.Cog):
                 ):
                     await audit.user.send(
                         embed=disnake.Embed(
-                            title="Modification des permissions du role **ULB**.",
-                            description=f"Vous avez autorisé le role **@{after.name}** du serveur **{after.guild.name}** à modifier son propre pseudo.\nCe role est paramètré comme le role **ULB** qui est attribué automatiquement aux membres ayant vérifiés leur email **ULB** et ce serveur est paramètré pour ces membres soient renommé avec leur vrai nom.\nSi vous gardez les permissions et paramètres actuels, les nouveaux membres vérifiés seront toujours renommés automatiquement mais pourront changer leur pseudo ensuite.\nSi vous désirez changer mes paramètres pour ce serveur, vous pouvez utiliser **/setup** dans le serveur.",
+                            title="Modification des permissions du rôle **ULB**.",
+                            description=f"Vous avez autorisé le rôle **@{after.name}** du serveur **{after.guild.name}** à modifier son propre pseudo.\nCe rôle est paramètré comme le rôle **ULB** qui est attribué automatiquement aux membres ayant vérifiés leur email **ULB** et ce serveur est paramètré pour que ces membres soient renommés avec leur vrai nom.\nSi vous gardez les permissions et paramètres actuels, les nouveaux membres vérifiés seront toujours renommés automatiquement mais pourront changer leur pseudo ensuite.\nSi vous désirez changer mes paramètres pour ce serveur, vous pouvez utiliser **/setup** dans le serveur.",
                             color=disnake.Colour.orange(),
                         )
                     )
@@ -295,8 +295,8 @@ class Ulb(commands.Cog):
                 if audit.target == role:
                     await audit.user.send(
                         embed=disnake.Embed(
-                            title="Supression du role **ULB**.",
-                            description=f"""Vous avez supprimé le role **@{role.name}** du serveur **{role.guild.name}**.\nCe role était paramétré comme le role **ULB** qui était attribué automatiquement aux membres ayant vérifiés leur email **ULB**.\nCette functionnalité a été retirée et vous devez la re-configurer en utilisant **"/setup"** dans le serveur.""",
+                            title="Supression du rôle **ULB**.",
+                            description=f"""Vous avez supprimé le rôle **@{role.name}** du serveur **{role.guild.name}**.\nCe rôle était paramétré comme le rôle **ULB** qui était attribué automatiquement aux membres ayant vérifiés leur email **ULB**.\nCette fonctionnalité a été retirée et vous devrez la re-configurer en utilisant **"/setup"** dans le serveur.""",
                             color=disnake.Colour.red(),
                         )
                     )
@@ -328,14 +328,14 @@ class Ulb(commands.Cog):
             if audit.target == guild.me:
                 embed = disnake.Embed(
                     title="Nouveau serveur",
-                    description=f"Vous venez de m'inviter dans le serveur {guild.name}, mais je n'ai pas les autorisations suffisantes pour être utilisé.\nDonnez moi les autorisations listées ci-dessous et changez la position de mon role ({guild.me.top_role.mention}) dans la liste des roles du serveur pour que je sois juste en dessous des moderateurs.\nPour plus d'informations, consultez la page [github](https://github.com/bepolytech/ULBDiscordBot).",
+                    description=f"Vous venez de m'inviter dans le serveur {guild.name}, mais je n'ai pas les autorisations suffisantes pour être utilisé.\nDonnez moi les autorisations listées ci-dessous et changez la position de mon rôle ({guild.me.top_role.mention}) dans la liste des rôles du serveur pour que je sois juste en dessous des modérateurs.\nPour plus d'informations, consultez ma page [Github](https://github.com/bepolytech/ULBDiscordBot).",
                     color=disnake.Colour.red(),
                 )
                 perms = guild.me.top_role.permissions
                 if perms.manage_roles != True:
                     embed.add_field(
                         name="❌",
-                        value="Je n'ai pas la permissions de **changer les roles**, ce dont j'ai besoin pour ajouter les membres vérifiés au role correspondant.",
+                        value="Je n'ai pas la permissions de **changer les rôles**, ce dont j'ai besoin pour ajouter les membres vérifiés au rôle correspondant.",
                         inline=False,
                     )
                 if perms.manage_nicknames != True:
@@ -351,7 +351,7 @@ class Ulb(commands.Cog):
                     await audit.user.send(
                         embed=disnake.Embed(
                             title="Nouveau serveur",
-                            description=f"Vous venez de m'inviter dans le serveur {guild.name}.\nChangez la position de mon role ({guild.me.top_role.mention}) dans la liste des roles du serveur pour que que je sois juste en dessous des moderateurs.\nUtilisez ensuite la commande **/setup** dans le serveur pour me configurer.\nPour plus d'informations, consultez la page [github](https://github.com/bepolytech/ULBDiscordBot).",
+                            description=f"Vous venez de m'inviter dans le serveur {guild.name}.\nChangez la position de mon rôle ({guild.me.top_role.mention}) dans la liste des rôles du serveur pour que que je sois juste en dessous des modérateurs.\nUtilisez ensuite la commande **/setup** dans le serveur pour me configurer.\nPour plus d'informations, consultez ma page [Github](https://github.com/bepolytech/ULBDiscordBot).",
                             color=disnake.Colour.green(),
                         )
                     )


### PR DESCRIPTION
Add a /feedback cmd available to everyone to send feedback about issue or improvement ideas directly from discord.
#13  Change the /ulb cmd to make unregistration possible when the user using it is registered. 