### PR TITLE
Update Python to 3.11.6 and upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM python:3
-FROM python:3.8.6-alpine
+FROM python:3.11.6-alpine
 # use python:3.11.0rc2-slim for less vulnerabilities ? (from `docker scan`)
 # use python:3.8.6 for no pip dependencies build errors ?
 # use python:alpine for reduced size

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.8.3
 aiosignal==1.2.0
-async-timeout==4.0.2
+#async-timeout==4.0.2
+async-timeout==4.0.3
 #asyncpg==0.26.0
 asyncpg==0.29.0
 attrs==22.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 aiohttp==3.8.3
 aiosignal==1.2.0
 async-timeout==4.0.2
-asyncpg==0.26.0
+#asyncpg==0.26.0
+asyncpg==0.29.0
 attrs==22.1.0
 autopep8==1.7.0
 cachetools==5.2.0
@@ -13,7 +14,8 @@ classify-imports==4.2.0
 disnake==2.6.0
 distlib==0.3.6
 filelock==3.8.0
-frozenlist==1.3.0
+#frozenlist==1.3.1
+frozenlist==1.4.0
 google-auth==2.11.1
 google-auth-oauthlib==0.5.3
 gspread==5.5.0
@@ -21,7 +23,8 @@ httplib2==0.20.4
 identify==2.5.5
 idna==3.4
 lor-deckcodes==5.0.0
-multidict==6.0.2
+#multidict==6.0.2
+multidict==6.0.4
 mypy==0.971
 mypy-extensions==0.4.3
 nodeenv==1.7.0
@@ -48,4 +51,5 @@ tomli==2.0.1
 typing_extensions==4.3.0
 urllib3==1.26.12
 virtualenv==20.16.3
-yarl==1.8.1
+#yarl==1.8.1
+yarl==1.9.3


### PR DESCRIPTION
also adds fix for the older docker build fail

@OscarVsp if you're interested