### PR TITLE
fix #36 : rename user choice during update_all_guilds for admins' `/update`

### DIFF
--- a/classes/utils.py
+++ b/classes/utils.py
@@ -141,7 +141,7 @@ async def update_guild(guild: disnake.Guild, *, role: disnake.Role = None, renam
             await update_member(member, role=role, rename=rename)
 
 
-async def update_all_guilds() -> None:
+async def update_all_guilds(force_rename: bool = False) -> None:
     """Update all guilds.
 
     This create tasks to do it.
@@ -149,7 +149,7 @@ async def update_all_guilds() -> None:
     logging.info("[Utils] Checking all guilds...")
     await asyncio.gather(
         *[
-            update_guild(guild, role=guild_data.role, rename=guild_data.rename)
+            update_guild(guild, role=guild_data.role, rename=force_rename if guild_data.rename else guild_data.rename) # force rename users only if both the guild has rename enabled and the admin set the update to force rename true
             for guild, guild_data in Database.ulb_guilds.items()
         ]
     )

--- a/cogs/Admin.py
+++ b/cogs/Admin.py
@@ -26,12 +26,21 @@ class Admin(commands.Cog):
         default_member_permissions=disnake.Permissions.all(),
         dm_permission=False,
     )
-    async def update(self, inter: disnake.ApplicationCommandInteraction):
+    async def update(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        rename: str = commands.Param(
+            description="Forcer un rename à tous les utilisateur.rice.s avec l'update ? (Seulment dans les serveurs ayant le rename d'activé)",
+            default="Non",
+            choices=["Non", "Oui"],
+        ),
+    ):
+        force_rename = rename == "Oui"  # Convert from str to bool
         await inter.response.defer(ephemeral=True)
         Database.load(self.bot)
-        await utils.update_all_guilds()
+        await utils.update_all_guilds(force_rename)
         await inter.edit_original_response(
-            embed=disnake.Embed(description="All servers updated !", color=disnake.Color.green())
+            embed=disnake.Embed(description=f"All servers updated !{" Members renamed." if force_rename else ""}", color=disnake.Color.green())
         )
 
     @commands.slash_command(

--- a/cogs/Admin.py
+++ b/cogs/Admin.py
@@ -37,11 +37,12 @@ class Admin(commands.Cog):
     ):
         force_rename = rename == "Oui"  # Convert from str to bool
         await inter.response.defer(ephemeral=True)
-        Database.load(self.bot)
-        await utils.update_all_guilds(force_rename)
-        await inter.edit_original_response(
-            embed=disnake.Embed(description=f"All servers updated !{" Members renamed." if force_rename else ""}", color=disnake.Color.green())
-        )
+        await Database.load(self.bot)
+        if (Database.loaded):
+            await utils.update_all_guilds(force_rename)
+            await inter.edit_original_response(
+                embed=disnake.Embed(description=f"All servers updated !{" Members renamed." if force_rename else ""}", color=disnake.Color.green())
+            )
 
     @commands.slash_command(
         name="yearly-update",


### PR DESCRIPTION
Fixes #36  
During an update_all_guilds command, only updates the user's name if both the guild has rename enabled AND the admin set force rename to true at the command.  

> need to test this in dev environment